### PR TITLE
Pluck non-contiguous rows from DataFrame

### DIFF
--- a/src/main/scala/com/audienceproject/crossbow/DataFrame.scala
+++ b/src/main/scala/com/audienceproject/crossbow/DataFrame.scala
@@ -26,13 +26,13 @@ class DataFrame private(
       (data, tup) => data(index) *: tup
 
   /**
-   * Retrieve a subset of rows from this DataFrame based on range of indices.
+   * Retrieve a subset of rows from this DataFrame based on indices.
    *
-   * @param range range of row indices to retrieve
+   * @param indices row indices to retrieve
    * @return new DataFrame
    */
-  def apply(range: Range): DataFrame =
-    slice(range, sortKey)
+  def apply(indices: IndexedSeq[Int]): DataFrame =
+    slice(indices, sortKey)
 
   /**
    * Select a subset of columns from this DataFrame.
@@ -289,12 +289,12 @@ class DataFrame private(
     def apply(index: Int): T = DataFrame.this.apply(index).asInstanceOf[T]
 
     /**
-     * Retrieve a subset of rows from this view based on range of indices.
+     * Retrieve a subset of rows from this view based on row indices.
      *
-     * @param range range of row indices to retrieve
+     * @param indices row indices to retrieve
      * @return sequence of rows of type 'T'
      */
-    def apply(range: Range): Seq[T] = for (i <- range) yield this (i)
+    def apply(indices: IndexedSeq[Int]): Seq[T] = for (i <- indices) yield this (i)
 
     override def iterator: Iterator[T] = this (0 until rowCount).iterator
 

--- a/src/test/scala/com/audienceproject/crossbow/core/SubsetTest.scala
+++ b/src/test/scala/com/audienceproject/crossbow/core/SubsetTest.scala
@@ -1,0 +1,27 @@
+package com.audienceproject.crossbow.core
+
+import com.audienceproject.crossbow.DataFrame
+import com.audienceproject.crossbow.schema.{Column, Schema}
+import org.scalatest.funsuite.AnyFunSuite
+
+class SubsetTest extends AnyFunSuite:
+
+  private val dataframe = DataFrame.fromColumns(IndexedSeq(0 until 100), Schema(Seq(Column[Int]("idx"))))
+
+  test("Retrieve single row by index"):
+    assertResult(0)(dataframe(0))
+    assertResult(10)(dataframe(10))
+    assertResult(45)(dataframe(45))
+    assertResult(99)(dataframe(99))
+
+  test("Retrieve contiguous range"):
+    val range = 33 to 38
+    val subset = dataframe(range)
+
+    assert(range.iterator.sameElements(subset.iterator))
+
+  test("Retrieve non-contiguous range"):
+    val indices = IndexedSeq(5, 16, 27, 38, 49, 60, 71, 82, 93)
+    val subset = dataframe(indices)
+
+    assert(indices.iterator.sameElements(subset.iterator))


### PR DESCRIPTION
Allow users to pluck, potentially non-contiguous, rows from a DataFrame. Before this patch, this could only be achieved by an inner join with all the performance penalties that incurs.