### PR TITLE
Build data frame column by column

### DIFF
--- a/src/main/scala/com/audienceproject/crossbow/DataFrame.scala
+++ b/src/main/scala/com/audienceproject/crossbow/DataFrame.scala
@@ -368,4 +368,62 @@ object DataFrame:
         spliceColumns(combinedData, schema.columns(i).columnType)
       DataFrame(colData.toVector, schema)
 
+  /**
+   * Returns an empty builder.
+   */
+  def builder(): Builder = EmptyBuilder
+
+  /**
+   * A builder for constructing a DataFrame by adding columns one at a time with specified data and types. Using
+   * `withColumn` variants without the type tag avoids auto-boxing of simple numeric types.
+   */
+  trait Builder:
+    protected def withColumnAny(columnType: RuntimeType, name: String, column: Array[?]): Builder
+    /**
+     * Return a DataFrame with all the columns that have been added so far.
+     */
+    def toDataFrame: DataFrame
+    /**
+     * Add a `Long` column with the given name and row data.
+     */
+    def withColumn(name: String, column: Array[Long]): Builder = withColumnAny(RuntimeType.Long, name, column)
+    /**
+     * Add an `Int` column with the given name and row data.
+     */
+    def withColumn(name: String, column: Array[Int]): Builder = withColumnAny(RuntimeType.Int, name, column)
+    /**
+     * Add a `Double` column with the given name and row data.
+     */
+    def withColumn(name: String, column: Array[Double]): Builder = withColumnAny(RuntimeType.Double, name, column)
+    /**
+     * Add a `Float` column with the given name and row data.
+     */
+    def withColumn(name: String, column: Array[Float]): Builder = withColumnAny(RuntimeType.Float, name, column)
+    /**
+     * Add a `Boolean` column with the given name and row data.
+     */
+    def withColumn(name: String, column: Array[Boolean]): Builder = withColumnAny(RuntimeType.Boolean, name, column)
+    /**
+     * Add a column with the given name and row data.
+     */
+    def withColumn[T: TypeTag](name: String, columnData: Array[T]): Builder =
+      val columnType = summon[TypeTag[T]].runtimeType
+      withColumnAny(columnType, name, columnData)
+  end Builder
+
+  private object EmptyBuilder extends Builder:
+    override def toDataFrame: DataFrame = DataFrame.empty
+    protected def withColumnAny(columnType: RuntimeType, name: String, column: Array[?]): Builder =
+      val columnSchema = Column(name, columnType)
+      NonEmptyBuilder(DataFrame(Vector(column), Schema(Seq(columnSchema))))
+  end EmptyBuilder
+
+  private class NonEmptyBuilder(dataFrame: DataFrame) extends Builder:
+    def toDataFrame: DataFrame = dataFrame
+    protected def withColumnAny(columnType: RuntimeType, name: String, column: Array[?]): Builder =
+      if (column.length != dataFrame.rowCount)
+        throw IllegalArgumentException(s"Column '$name' must contain ${dataFrame.rowCount} rows. Was ${column.length}.")
+      val columnSchema = Column(name, columnType)
+      NonEmptyBuilder(DataFrame(dataFrame.columnData :+ column, dataFrame.schema.add(columnSchema)))
+  end NonEmptyBuilder
 end DataFrame

--- a/src/test/scala/com/audienceproject/crossbow/core/ConstructionTest.scala
+++ b/src/test/scala/com/audienceproject/crossbow/core/ConstructionTest.scala
@@ -25,3 +25,39 @@ class ConstructionTest extends AnyFunSuite:
     val df = Seq.empty[(Int, Float)].toDataFrame("a", "b")
     assertResult(2)(df.numColumns)
     assertResult(Schema(Seq(Column[Int]("a"), Column[Float]("b"))))(df.schema)
+
+  test("Construct using builder supports empty columns"):
+    val expectedSchema = Schema(Seq(Column[Int]("a"), Column[Float]("b"), Column[String]("c"), Column[Integer]("d")))
+
+    val df = DataFrame.builder()
+      .withColumn("a", Array.empty[Int])
+      .withColumn("b", Array.empty[Float])
+      .withColumn("c", Array.empty[String])
+      .withColumn("d", Array.empty[Integer])
+      .toDataFrame
+
+    assertResult(4)(df.numColumns)
+    assertResult(0)(df.rowCount)
+    assertResult(expectedSchema)(df.schema)
+
+  test("Construct using builder produces valid dataframe"):
+    val expectedSchema = Schema(Seq(Column[Int]("a"), Column[Float]("b"), Column[String]("c"), Column[Integer]("d")))
+    val expectedRows = Seq((1, 0.1f, "a", 10), (2, 0.2f, "b", 20), (3, 0.3f, "c", 30))
+
+    val df = DataFrame.builder()
+      .withColumn("a", Array(1, 2, 3))
+      .withColumn("b", Array(0.1f, 0.2f, 0.3f))
+      .withColumn("c", Array("a", "b", "c"))
+      .withColumn("d", Array(10, 20, 30).map(Int.box))
+      .toDataFrame
+
+    assertResult(4)(df.numColumns)
+    assertResult(3)(df.rowCount)
+    assertResult(expectedSchema)(df.schema)
+    assertResult(expectedRows)(df.as[(Int, Float, String, Integer)].toSeq)
+
+  test("Construct using builder prevents jagged dataframe"):
+    val ex = intercept[IllegalArgumentException]:
+      DataFrame.builder().withColumn("a", Array(1, 2, 3)).withColumn("b", Array(0.1f, 0.2f))
+
+    assertResult("Column 'b' must contain 3 rows. Was 2.")(ex.getMessage)


### PR DESCRIPTION
Recent revelations have made it apparent that `DataFrame.fromColumns()` can cause auto-boxing of simple values due to Any in the signature. Boxed values are immediately converted back to simple numeric types afterwards in convert(). This is obviously a waste of both CPU and memory resources, and the 3-4x* memory increase becomes problematic as the number of rows increases.

Adding a builder pattern to construct a data frame column by column avoids auto-boxing of simple types.

*) `Long` and `Double` consume 3x memory when boxed. `Int` and Float consume 4x memory when boxed, while a boxed `Boolean` consumes up to 16x memory in the worst case.